### PR TITLE
Adapting ghistogram to accomodate exponential growth

### DIFF
--- a/ghistogram.go
+++ b/ghistogram.go
@@ -17,131 +17,300 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"strconv"
 	"sync"
+	"sync/atomic"
 )
+
+// An individual bin of the histogram structure
+type HistogramBin struct {
+	_count uint64
+	_start uint64
+	_end   uint64
+}
+
+func (hb *HistogramBin) assign(src *HistogramBin) {
+	hb._count = src._count
+	hb._start = src._start
+	hb._end = src._end
+}
+
+// Returns the count in this bin
+func (hb *HistogramBin) count() uint64 {
+	return atomic.LoadUint64(&hb._count)
+}
+
+// Increment this bin by the given amount
+func (hb *HistogramBin) incr(amount uint64) {
+	atomic.AddUint64(&hb._count, amount)
+}
+
+// Set a specific value for this bin
+func (hb *HistogramBin) set(val uint64) {
+	atomic.StoreUint64(&hb._count, val)
+}
+
+// Checks if this bin can contain the value
+func (hb *HistogramBin) accepts(value uint64) bool {
+	return value >= hb._start &&
+		(value < hb._end || value == math.MaxUint64)
+}
+
+// A bin generator that generates bin ranges of the order:
+// [n*i, n*(i+1)]
+type MultipleGenerator struct {
+	_start   uint64
+	_factor  float64
+	_initial int
+}
+
+func (mg *MultipleGenerator) getBin() *HistogramBin {
+	var start, end uint64
+	if mg._factor == 0.0 {
+		start = mg._start
+		mg._start += uint64(mg._initial)
+		end = mg._start
+	} else {
+		if mg._initial != -1 {
+			start = uint64(mg._initial)
+			end = uint64(float64(mg._start) * mg._factor)
+			mg._initial = -1
+		} else {
+			start = uint64(float64(mg._start) * mg._factor)
+			end = uint64(float64(start) * mg._factor)
+			mg._start = start
+		}
+	}
+
+	return &HistogramBin{
+		_count: 0,
+		_start: start,
+		_end:   end,
+	}
+}
+
+// A bin generator that generates bin ranges of the order:
+// [n^i, n^(i+1)]
+type ExponentialGenerator struct {
+	_start uint64
+	_power float64
+}
+
+func (eg *ExponentialGenerator) getBin() *HistogramBin {
+	start := uint64(math.Pow(eg._power, float64(eg._start)))
+	eg._start++
+	end := uint64(math.Pow(eg._power, float64(eg._start)))
+	return &HistogramBin{
+		_count: 0,
+		_start: start,
+		_end:   end,
+	}
+}
 
 // Histogram is a simple uint64 histogram implementation that avoids
 // heap allocations during its processing of incoming data points.
+// These array of bins is public - in case users wish to use reflection
+// or JSON marhsaling.
 //
-// It was motivated for tracking simple performance timings.
-//
-// The histogram bins are split across the two arrays of Ranges and
-// Counts, where len(Ranges) == len(Counts).  These arrays are public
-// in case users wish to use reflection or JSON marhsaling.
-//
-// An optional growth factor for bin sizes is supported - see
-// NewHistogram() binGrowthFactor parameter.
-//
-// The histogram is concurrent safe.
+// --> Motivated for tracking simple performance timings.
+// --> The histogram is concurrent safe.
 type Histogram struct {
-	// Ranges holds the lower domain bounds of bins, so bin i has data
-	// point domain of "[Ranges[i], Ranges[i+1])".  Related,
-	// Ranges[0] == 0 and Ranges[1] == binFirst.
-	Ranges []uint64
-
-	// Counts holds the event counts for bins.
-	Counts []uint64
-
-	// TotCount is the sum of all counts.
-	TotCount uint64
-
-	TotDataPoint uint64 // TotDataPoint is the sum of all data points.
-	MinDataPoint uint64 // MinDataPoint is the smallest data point seen.
-	MaxDataPoint uint64 // MaxDataPoint is the largest data point seen.
+	// Name assogicated with the histogram
+	_name string
+	// Array of histogram bins
+	_bins []HistogramBin
 
 	m sync.Mutex
 }
 
+// Populates the histogram bins using the multiple generator
+func (gh *Histogram) fillMultiples(mg *MultipleGenerator) {
+	for i := 0; i < len(gh._bins); i++ {
+		gh._bins[i].assign(mg.getBin())
+	}
+	gh.completeBinArray()
+}
+
+// Populates the histogram bins using the exponential generator
+func (gh *Histogram) fillExponential(eg *ExponentialGenerator) {
+	for i := 0; i < len(gh._bins); i++ {
+		gh._bins[i].assign(eg.getBin())
+	}
+	gh.completeBinArray()
+}
+
+// Adds first and last bins if necessary
+func (gh *Histogram) completeBinArray() {
+	// If there will not naturally be one, create a bin for the
+	// smallest possible value
+	start_of_first_bin := gh._bins[0]._start
+	if start_of_first_bin > 0 {
+		hb := HistogramBin{
+			_count: 0,
+			_start: 0,
+			_end:   start_of_first_bin,
+		}
+		gh._bins = append([]HistogramBin{hb}, gh._bins...)
+	}
+
+	// Also create one reaching to the largest possible value
+	end_of_last_bin := gh._bins[len(gh._bins)-1]._end
+	if end_of_last_bin < math.MaxUint64 {
+		hb := HistogramBin{
+			_count: 0,
+			_start: end_of_last_bin,
+			_end:   math.MaxUint64,
+		}
+		gh._bins = append(gh._bins, hb)
+	}
+
+	gh.verify()
+}
+
+// This validates that we're sorted and have no gaps or overlaps. Returns
+// true if tests pass, else false
+func (gh *Histogram) verify() bool {
+	prev := uint64(0)
+	for i := 0; i < len(gh._bins); i++ {
+		if gh._bins[i]._start != prev {
+			return false
+		}
+		prev = gh._bins[i]._end
+	}
+	if prev != math.MaxUint64 {
+		return false
+	}
+	return true
+}
+
+// Finds the bin containing the specified amount. Returns index of last bin
+// if not found
+func (gh *Histogram) findBin(amount uint64) *HistogramBin {
+	if amount == math.MaxUint64 {
+		return &gh._bins[len(gh._bins)-1]
+	}
+
+	index := len(gh._bins) - 1
+	for i := 0; i < len(gh._bins); i++ {
+		if amount < gh._bins[i]._end {
+			index = i
+			break
+		}
+	}
+
+	if !gh._bins[index].accepts(amount) {
+		return &gh._bins[len(gh._bins)-1]
+	}
+
+	return &gh._bins[index]
+}
+
 // NewHistogram creates a new, ready to use Histogram.  The numBins
-// must be >= 2.  The binFirst is the width of the first bin.  The
+// must be >= 1.  The binFirst is the width of the first bin.  The
 // binGrowthFactor must be > 1.0 or 0.0.
 //
-// A special case of binGrowthFactor of 0.0 means the the allocated
-// bins will have constant, non-growing size or "width".
+// Uses multiple generator to prepare the bins.
+//
+// A special case of binGrowthFactor of 0.0 means that the allocated
+// bins will have constant, now growing size or "width"
 func NewHistogram(
 	numBins int,
 	binFirst uint64,
 	binGrowthFactor float64) *Histogram {
+
+	mg := &MultipleGenerator{
+		_start:   binFirst,
+		_factor:  binGrowthFactor,
+		_initial: int(binFirst),
+	}
+
 	gh := &Histogram{
-		Ranges:       make([]uint64, numBins),
-		Counts:       make([]uint64, numBins),
-		TotCount:     0,
-		MinDataPoint: math.MaxUint64,
-		MaxDataPoint: 0,
+		_name: "Histogram",
+		_bins: make([]HistogramBin, numBins),
 	}
 
-	gh.Ranges[0] = 0
-	gh.Ranges[1] = binFirst
-
-	for i := 2; i < len(gh.Ranges); i++ {
-		if binGrowthFactor == 0.0 {
-			gh.Ranges[i] = gh.Ranges[i-1] + binFirst
-		} else {
-			gh.Ranges[i] =
-				uint64(math.Ceil(binGrowthFactor * float64(gh.Ranges[i-1])))
-		}
-	}
+	gh.fillMultiples(mg)
 
 	return gh
 }
 
-// Add increases the count in the bin for the given dataPoint.
-func (gh *Histogram) Add(dataPoint uint64, count uint64) {
-	gh.m.Lock()
+// NewExpHistogram creates a new, ready to use Histogram. The numBins
+// must be >= 1.
+//
+// Uses exponential generator to prepare the bins.
+//
+// If the growthFactor were less than or equal to 1.0, a default
+// of 2.0 will be applied.
+func NewExpHistogram(
+	name string,
+	numBins int,
+	growthFactor float64) *Histogram {
 
-	idx := search(gh.Ranges, dataPoint)
-	if idx >= 0 {
-		gh.Counts[idx] += count
-		gh.TotCount += count
-
-		gh.TotDataPoint += dataPoint
-		if gh.MinDataPoint > dataPoint {
-			gh.MinDataPoint = dataPoint
-		}
-		if gh.MaxDataPoint < dataPoint {
-			gh.MaxDataPoint = dataPoint
-		}
+	if growthFactor <= 1.0 {
+		growthFactor = 2.0
 	}
 
+	eg := &ExponentialGenerator{
+		_start: 0,
+		_power: growthFactor,
+	}
+
+	gh := &Histogram{
+		_name: name,
+		_bins: make([]HistogramBin, numBins),
+	}
+
+	gh.fillExponential(eg)
+
+	return gh
+}
+
+// Add a value to this histogram
+func (gh *Histogram) Add(amount uint64, count uint64) {
+	gh.m.Lock()
+	gh.findBin(amount).incr(count)
 	gh.m.Unlock()
 }
 
-// Finds the last arr index where the arr entry <= dataPoint.
-func search(arr []uint64, dataPoint uint64) int {
-	i, j := 0, len(arr)
-
-	for i < j {
-		h := i + (j-i)/2 // Avoids h overflow, where i <= h < j.
-		if dataPoint >= arr[h] {
-			i = h + 1
-		} else {
-			j = h
-		}
+// Set all bins to zero
+func (gh *Histogram) Reset() {
+	gh.m.Lock()
+	for i := 0; i < len(gh._bins); i++ {
+		gh._bins[i].set(0)
 	}
+	gh.m.Unlock()
+}
 
-	return i - 1
+// Gets the total number of samples counted
+func (gh *Histogram) Total() uint64 {
+	gh.m.Lock()
+	var count uint64
+	for i := 0; i < len(gh._bins); i++ {
+		count += gh._bins[i]._count
+	}
+	gh.m.Unlock()
+	return count
 }
 
 // AddAll adds all the Counts from the src histogram into this
-// histogram.  The src and this histogram must either have the same
+// histogram.  The src and this histogram must have the same
 // exact creation parameters.
 func (gh *Histogram) AddAll(src *Histogram) {
+	if len(gh._bins) != len(src._bins) {
+		fmt.Errorf("Error: Bin-count mismatch: %d != %d",
+			len(gh._bins), len(src._bins))
+		return
+	}
+
 	src.m.Lock()
 	gh.m.Lock()
 
-	for i := 0; i < len(src.Counts); i++ {
-		gh.Counts[i] += src.Counts[i]
+	for i := 0; i < len(src._bins); i++ {
+		if gh._bins[i]._start == src._bins[i]._start &&
+			gh._bins[i]._end == src._bins[i]._end {
+			gh._bins[i]._count += src._bins[i]._count
+		}
 	}
-	gh.TotCount += src.TotCount
-
-	gh.TotDataPoint += src.TotDataPoint
-	if gh.MinDataPoint > src.MinDataPoint {
-		gh.MinDataPoint = src.MinDataPoint
-	}
-	if gh.MaxDataPoint < src.MaxDataPoint {
-		gh.MaxDataPoint = src.MaxDataPoint
-	}
+	copy(src._bins, gh._bins)
 
 	gh.m.Unlock()
 	src.m.Unlock()
@@ -157,57 +326,59 @@ func (gh *Histogram) AddAll(src *Histogram) {
 //      20+  10=3 10.00% ************
 func (gh *Histogram) EmitGraph(prefix []byte,
 	out *bytes.Buffer) *bytes.Buffer {
-	gh.m.Lock()
-
-	ranges := gh.Ranges
-	rangesN := len(ranges)
-	counts := gh.Counts
-	countsN := len(counts)
-
 	if out == nil {
-		out = bytes.NewBuffer(make([]byte, 0, 80*countsN))
+		out = bytes.NewBuffer(make([]byte, 0, 80*len(gh._bins)))
 	}
-
-	var maxCount uint64
-	for _, c := range counts {
-		if maxCount < c {
-			maxCount = c
-		}
-	}
-	maxCountF := float64(maxCount)
-	totCountF := float64(gh.TotCount)
-
-	widthRange := len(strconv.Itoa(int(ranges[rangesN-1])))
-	widthWidth := len(strconv.Itoa(int(ranges[rangesN-1] - ranges[rangesN-2])))
-	widthCount := len(strconv.Itoa(int(maxCount)))
-
-	// Each line looks like: "[prefix]START+WIDTH=COUNT PCT% BAR\n"
-	f := fmt.Sprintf("%%%dd+%%%dd=%%%dd%% 7.2f%%%%",
-		widthRange, widthWidth, widthCount)
-
-	var runCount uint64 // Running total while emitting lines.
 
 	barLen := float64(len(bar))
 
-	for i, c := range counts {
+	var totalCount uint64
+	var maxCount uint64
+	var ranges []string
+	var longestRange int
+
+	gh.m.Lock()
+
+	for i := 0; i < len(gh._bins); i++ {
+		totalCount += gh._bins[i]._count
+		if maxCount < gh._bins[i]._count {
+			maxCount = gh._bins[i]._count
+		}
+
+		var temp string
+		if gh._bins[i]._end != math.MaxUint64 {
+			temp = fmt.Sprintf("%v - %v", gh._bins[i]._start, gh._bins[i]._end)
+		} else {
+			temp = fmt.Sprintf("%v - inf", gh._bins[i]._start)
+		}
+		ranges = append(ranges, temp)
+		if gh._bins[i]._count > 0 && longestRange < len(temp) {
+			longestRange = len(temp)
+		}
+	}
+
+	fmt.Fprintf(out, "%s (%v Total)\n", gh._name, totalCount)
+	for i := 0; i < len(gh._bins); i++ {
+		binCount := gh._bins[i]._count
+		if binCount == 0 {
+			continue
+		}
+
+		var padding string
+		for j := 0; j < (longestRange - len(ranges[i])); j++ {
+			padding = padding + " "
+		}
+
 		if prefix != nil {
 			out.Write(prefix)
 		}
 
-		var width uint64
-		if i < countsN-1 {
-			width = uint64(ranges[i+1] - ranges[i])
-		}
+		fmt.Fprintf(out, "[%s] %s%10v %7.2f%%",
+			ranges[i], padding, binCount, 100.0*(float64(binCount)/float64(totalCount)))
 
-		runCount += c
-		fmt.Fprintf(out, f, ranges[i], width, c,
-			100.0*(float64(runCount)/totCountF))
-
-		if c > 0 {
-			out.Write([]byte(" "))
-			barWant := int(math.Floor(barLen * (float64(c) / maxCountF)))
-			out.Write(bar[0:barWant])
-		}
+		out.Write([]byte(" "))
+		barWant := int(math.Floor(barLen * (float64(binCount) / float64(maxCount))))
+		out.Write(bar[0:barWant])
 
 		out.Write([]byte("\n"))
 	}
@@ -217,7 +388,7 @@ func (gh *Histogram) EmitGraph(prefix []byte,
 	return out
 }
 
-var bar = []byte("******************************")
+var bar = []byte("##############################")
 
 // CallSync invokes the callback func while the histogram is locked.
 func (gh *Histogram) CallSync(f func()) {

--- a/ghistogram_test.go
+++ b/ghistogram_test.go
@@ -2,65 +2,16 @@ package ghistogram
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
-
-func TestSearch(t *testing.T) {
-	tests := []struct {
-		arr []uint64
-		val uint64
-		exp int
-	}{
-		{[]uint64(nil), 0, -1},
-		{[]uint64(nil), 100, -1},
-
-		{[]uint64{0}, 0, 0},
-		{[]uint64{0, 10}, 0, 0},
-		{[]uint64{0, 10, 20}, 0, 0},
-
-		{[]uint64{0}, 1, 0},
-		{[]uint64{0, 10}, 1, 0},
-		{[]uint64{0, 10, 20}, 1, 0},
-
-		{[]uint64{0}, 10, 0},
-		{[]uint64{0, 10}, 10, 1},
-		{[]uint64{0, 10, 20}, 10, 1},
-
-		{[]uint64{0}, 15, 0},
-		{[]uint64{0, 10}, 15, 1},
-		{[]uint64{0, 10, 20}, 15, 1},
-
-		{[]uint64{0}, 20, 0},
-		{[]uint64{0, 10}, 20, 1},
-		{[]uint64{0, 10, 20}, 20, 2},
-
-		{[]uint64{0}, 30, 0},
-		{[]uint64{0, 10}, 30, 1},
-		{[]uint64{0, 10, 20}, 30, 2},
-	}
-
-	for testi, test := range tests {
-		got := search(test.arr, test.val)
-		if got != test.exp {
-			t.Errorf("test #%d, arr: %v, val: %d, exp: %d, got: %d",
-				testi, test.arr, test.val, test.exp, got)
-		}
-		if got >= 0 &&
-			got < len(test.arr) &&
-			test.arr[got] > test.val {
-			t.Errorf("test #%d, test.arr[got] > test.val,"+
-				" arr: %v, val: %d, exp: %d, got: %d",
-				testi, test.arr, test.val, test.exp, got)
-		}
-	}
-}
 
 func TestNewHistogram(t *testing.T) {
 	tests := []struct {
 		numBins         int
 		binFirst        uint64
 		binGrowthFactor float64
-		exp             []uint64
+		ent             []uint64
 	}{
 		{2, 123, 10.0, []uint64{0, 123}},
 		{2, 123, 10.0, []uint64{0, 123}},
@@ -75,73 +26,107 @@ func TestNewHistogram(t *testing.T) {
 	}
 
 	for testi, test := range tests {
-		gh := NewHistogram(
-			test.numBins, test.binFirst, test.binGrowthFactor)
-		if len(gh.Ranges) != len(gh.Counts) {
-			t.Errorf("mismatched len's")
+		gh := NewHistogram(test.numBins, test.binFirst, test.binGrowthFactor)
+		for i := 0; i < len(test.ent); i++ {
+			gh.Add(test.ent[i], 1)
 		}
-		if len(gh.Ranges) != test.numBins {
-			t.Errorf("wrong len's")
+
+		if gh._name != "Histogram" {
+			t.Errorf("test #%d: Incorrect name of histogram!", testi)
 		}
-		if len(gh.Ranges) != len(test.exp) {
-			t.Errorf("unequal len's")
+
+		if gh.Total() != uint64(len(test.ent)) {
+			t.Errorf("test #%d: Incorrect total count", testi)
 		}
-		for i := 0; i < len(gh.Ranges); i++ {
-			if gh.Ranges[i] != test.exp[i] {
-				t.Errorf("test #%d, actual (%v) != exp (%v)",
-					testi, gh.Ranges, test.exp)
-			}
+
+		if len(gh._bins) != test.numBins+2 {
+			t.Errorf("test #%d: Incorrect number of bins", testi)
+		}
+	}
+}
+
+func TestNewExpHistogram(t *testing.T) {
+	tests := []struct {
+		numBins         int
+		binGrowthFactor float64
+		ent             []uint64
+	}{
+		{2, 2.0, []uint64{0, 123}},
+		{2, 3.0, []uint64{0, 123}},
+
+		{5, 0.0, []uint64{0, 10, 20, 30, 40}},
+		{5, 1.5, []uint64{0, 10, 15, 23, 35}},
+		{5, 2.0, []uint64{0, 10, 100, 1000, 10000}},
+	}
+
+	for testi, test := range tests {
+		name := fmt.Sprintf("test#%d", testi)
+		gh := NewExpHistogram(name, test.numBins, test.binGrowthFactor)
+		for i := 0; i < len(test.ent); i++ {
+			gh.Add(test.ent[i], 1)
+		}
+
+		if gh._name != name {
+			t.Errorf("test #%d: Incorrect name of histogram!", testi)
+		}
+
+		if gh.Total() != uint64(len(test.ent)) {
+			t.Errorf("test #%d: Incorrect total count", testi)
+		}
+
+		if len(gh._bins) != test.numBins+2 {
+			t.Errorf("test #%d: Incorrect number of bins", testi)
 		}
 	}
 }
 
 func TestAdd(t *testing.T) {
-	// Bins will look like: {0, 10, 20, 40, 80}.
+	// Bins will look like: {0-10, 10-20, 20-40, 40-80, 80-160, 160-320, 320-inf}
 	gh := NewHistogram(5, 10, 2.0)
 
 	tests := []struct {
 		val uint64
 		exp []uint64
 	}{
-		{0, []uint64{1, 0, 0, 0, 0}},
-		{0, []uint64{2, 0, 0, 0, 0}},
-		{0, []uint64{3, 0, 0, 0, 0}},
+		{0, []uint64{1, 0, 0, 0, 0, 0, 0}},
+		{0, []uint64{2, 0, 0, 0, 0, 0, 0}},
+		{0, []uint64{3, 0, 0, 0, 0, 0, 0}},
 
-		{2, []uint64{4, 0, 0, 0, 0}},
-		{3, []uint64{5, 0, 0, 0, 0}},
-		{4, []uint64{6, 0, 0, 0, 0}},
+		{2, []uint64{4, 0, 0, 0, 0, 0, 0}},
+		{3, []uint64{5, 0, 0, 0, 0, 0, 0}},
+		{4, []uint64{6, 0, 0, 0, 0, 0, 0}},
 
-		{10, []uint64{6, 1, 0, 0, 0}},
-		{11, []uint64{6, 2, 0, 0, 0}},
-		{12, []uint64{6, 3, 0, 0, 0}},
+		{10, []uint64{6, 1, 0, 0, 0, 0, 0}},
+		{11, []uint64{6, 2, 0, 0, 0, 0, 0}},
+		{12, []uint64{6, 3, 0, 0, 0, 0, 0}},
 
-		{100, []uint64{6, 3, 0, 0, 1}},
-		{90, []uint64{6, 3, 0, 0, 2}},
-		{80, []uint64{6, 3, 0, 0, 3}},
+		{100, []uint64{6, 3, 0, 0, 1, 0, 0}},
+		{90, []uint64{6, 3, 0, 0, 2, 0, 0}},
+		{80, []uint64{6, 3, 0, 0, 3, 0, 0}},
 
-		{20, []uint64{6, 3, 1, 0, 3}},
-		{30, []uint64{6, 3, 2, 0, 3}},
-		{40, []uint64{6, 3, 2, 1, 3}},
+		{20, []uint64{6, 3, 1, 0, 3, 0, 0}},
+		{30, []uint64{6, 3, 2, 0, 3, 0, 0}},
+		{40, []uint64{6, 3, 2, 1, 3, 0, 0}},
 	}
 
 	for testi, test := range tests {
 		gh.Add(test.val, 1)
 
-		for i := 0; i < len(gh.Counts); i++ {
-			if gh.Counts[i] != test.exp[i] {
+		for i := 0; i < len(gh._bins); i++ {
+			if gh._bins[i]._count != test.exp[i] {
 				t.Errorf("test #%d, actual (%v) != exp (%v)",
-					testi, gh.Counts, test.exp)
+					testi, gh._bins[i]._count, test.exp)
 			}
 		}
 
-		if gh.TotCount != uint64(testi+1) {
+		if gh.Total() != uint64(testi+1) {
 			t.Errorf("TotCounts wrong")
 		}
 	}
 }
 
 func TestAddAll(t *testing.T) {
-	// Bins will look like: {0, 10, 20, 40, 80}.
+	// Bins will look like: {0-10, 10-20, 20-40, 40-80, 80-160, 160-320, 320-inf}
 	gh := NewHistogram(5, 10, 2.0)
 
 	gh.Add(15, 2)
@@ -152,40 +137,45 @@ func TestAddAll(t *testing.T) {
 	gh2.AddAll(gh)
 	gh2.AddAll(gh)
 
-	exp := []uint64{0, 4, 6, 0, 2}
+	exp := []uint64{0, 4, 6, 0, 0, 0, 2}
 
-	for i := 0; i < len(gh2.Counts); i++ {
-		if gh2.Counts[i] != exp[i] {
+	for i := 0; i < len(gh2._bins); i++ {
+		if gh2._bins[i]._count != exp[i] {
 			t.Errorf("AddAll mismatch, actual (%v) != exp (%v)",
-				gh2.Counts, exp)
+				gh2._bins[i]._count, exp)
 		}
 	}
 
-	if gh2.TotCount != 12 {
+	if gh2.Total() != 12 {
 		t.Errorf("TotCount wrong")
 	}
 }
 
 func TestGraph(t *testing.T) {
-	// Bins will look like: {0, 10, 20, 40, 80, 160, 320}.
+	// Bins will look like: {[0 - 10], [10 - 20], [20 - 40], [40 - 80], [80 - 160],
+	//                       [160 - 320], [320 - 640], [640 - 1280], [1280 - inf]
 	gh := NewHistogram(7, 10, 2.0)
 
+	gh.Add(5, 2)
 	gh.Add(10, 20)
 	gh.Add(20, 10)
 	gh.Add(40, 3)
 	gh.Add(160, 2)
 	gh.Add(320, 1)
+	gh.Add(1280, 10)
 
 	buf := gh.EmitGraph([]byte("- "), nil)
 
-	exp := `-   0+ 10= 0   0.00%
--  10+ 10=20  55.56% ******************************
--  20+ 20=10  83.33% ***************
--  40+ 40= 3  91.67% ****
--  80+ 80= 0  91.67%
-- 160+160= 2  97.22% ***
-- 320+  0= 1 100.00% *
+	exp := `Histogram (48 Total)
+- [0 - 10]              2    4.17% ###
+- [10 - 20]            20   41.67% ##############################
+- [20 - 40]            10   20.83% ###############
+- [40 - 80]             3    6.25% ####
+- [160 - 320]           2    4.17% ###
+- [320 - 640]           1    2.08% #
+- [1280 - inf]         10   20.83% ###############
 `
+
 	got := buf.String()
 	if got != exp {
 		t.Errorf("didn't get expected graph,\ngot: %s\nexp: %s",


### PR DESCRIPTION
+ Changes to the way bins are tracked within the histogram
+ Accomodates the older way that supports growth by a factor
  - for backward compatability, and the new way of tracking
  the histogram bins with exponential growth.
+ New style of ASCII graph emitted by the histogram, for
  easier understanding:

    Histogram (48 Total)
    [0 - 10]              2    4.17% ###
    [10 - 20]            20   41.67% ##############################
    [20 - 40]            10   20.83% ###############
    [40 - 80]             3    6.25% ####
    [160 - 320]           2    4.17% ###
    [320 - 640]           1    2.08% #
    [1280 - inf]         10   20.83% ###############