### PR TITLE
Travis-ci: added support for ppc64le & latest go version updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: go
 
+arch:
+  - AMD64
+  - ppc64le
+
 go:
-  - 1.4
+  - 1.15
 
 before_install:
   - go get github.com/axw/gocov/gocov


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.